### PR TITLE
feat: add organization as an optional parameter in ADO connection creation

### DIFF
--- a/config-ui/src/api/connection/index.ts
+++ b/config-ui/src/api/connection/index.ts
@@ -52,6 +52,7 @@ export const test = (
       | 'proxy'
       | 'dbUrl'
       | 'companyId'
+      | 'organization'
     >
   >,
 ): Promise<IConnectionTestResult> =>
@@ -61,6 +62,15 @@ export const testOld = (
   plugin: string,
   payload: Pick<
     IConnectionAPI,
-    'endpoint' | 'authMethod' | 'username' | 'password' | 'token' | 'appId' | 'secretKey' | 'proxy' | 'dbUrl'
+    | 'endpoint'
+    | 'authMethod'
+    | 'username'
+    | 'password'
+    | 'token'
+    | 'appId'
+    | 'secretKey'
+    | 'proxy'
+    | 'dbUrl'
+    | 'organization'
   >,
 ): Promise<IConnectionOldTestResult> => request(`/plugins/${plugin}/test`, { method: 'post', data: payload });

--- a/config-ui/src/features/connections/utils.ts
+++ b/config-ui/src/features/connections/utils.ts
@@ -40,6 +40,7 @@ export const transformConnection = (plugin: string, connection: IConnectionAPI):
     proxy: connection.proxy,
     enableGraphql: connection.enableGraphql,
     rateLimitPerHour: connection.rateLimitPerHour,
+    organization: connection.organization,
   };
 };
 

--- a/config-ui/src/plugins/components/connection-form/index.tsx
+++ b/config-ui/src/plugins/components/connection-form/index.tsx
@@ -73,6 +73,7 @@ export const ConnectionForm = ({ plugin, connectionId, onSuccess }: Props) => {
               proxy: isEqual(connection?.proxy, values.proxy) ? undefined : values.proxy,
               dbUrl: isEqual(connection?.dbUrl, values.dbUrl) ? undefined : values.dbUrl,
               companyId: isEqual(connection?.companyId, values.companyId) ? undefined : values.companyId,
+              organization: isEqual(connection?.appId, values.organization) ? undefined : values.organization,
             })
           : API.connection.testOld(
               plugin,
@@ -89,6 +90,7 @@ export const ConnectionForm = ({ plugin, connectionId, onSuccess }: Props) => {
                 'tenantType',
                 'dbUrl',
                 'companyId',
+                'organization',
               ]),
             ),
       {

--- a/config-ui/src/plugins/register/azure/config.tsx
+++ b/config-ui/src/plugins/register/azure/config.tsx
@@ -21,7 +21,7 @@ import { DOC_URL } from '@/release';
 import { IPluginConfig } from '@/types';
 
 import Icon from './assets/icon.svg?react';
-import { BaseURL } from './connection-fields';
+import { BaseURL, ConnectionOrganization } from './connection-fields';
 
 export const AzureConfig: IPluginConfig = {
   plugin: 'azuredevops',
@@ -88,13 +88,16 @@ export const AzureGoConfig: IPluginConfig = {
       {
         key: 'token',
         label: 'Personal Access Token',
-        subLabel: (
-          <span>
-            <ExternalLink link={DOC_URL.PLUGIN.AZUREDEVOPS.AUTH_TOKEN}>Learn about how to create a PAT</ExternalLink>{' '}
-            Please select ALL ACCESSIBLE ORGANIZATIONS for the Organization field when you create the PAT.
-          </span>
-        ),
       },
+      ({ initialValues, values, setValues }: any) => (
+        <ConnectionOrganization
+          initialValue={initialValues}
+          label="Personal Access Token Scope"
+          key="ado-organization"
+          value={values.organization}
+          setValue={(value) => setValues({ organization: value })}
+        />
+      ),
       'proxy',
       {
         key: 'rateLimitPerHour',

--- a/config-ui/src/plugins/register/azure/connection-fields/index.ts
+++ b/config-ui/src/plugins/register/azure/connection-fields/index.ts
@@ -17,3 +17,4 @@
  */
 
 export * from './base-url';
+export * from './organization';

--- a/config-ui/src/plugins/register/azure/connection-fields/organization.tsx
+++ b/config-ui/src/plugins/register/azure/connection-fields/organization.tsx
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Input, Radio, type RadioChangeEvent } from 'antd';
+
+import { Block, ExternalLink } from '@/components';
+import { DOC_URL } from '@/release';
+
+interface Props {
+  initialValue: OrganizationSettings;
+  value: string;
+  label?: string;
+  setValue: (value: string) => void;
+}
+
+interface OrganizationSettings {
+  organization: string;
+  scoped: boolean;
+}
+
+export const ConnectionOrganization = ({ label, initialValue, value, setValue }: Props) => {
+  const [settings, setSettings] = useState<OrganizationSettings>({ scoped: false, organization: '' });
+
+  useEffect(() => {
+    const org = initialValue.organization || '';
+    setValue(org);
+
+    setSettings({ organization: initialValue.organization, scoped: org !== '' });
+  }, [initialValue.organization]);
+
+  const handleChange = (e: RadioChangeEvent) => {
+    const scoped = e.target.value;
+    if (scoped) {
+      setValue(settings.organization);
+    } else {
+      setValue('');
+    }
+    setSettings({ ...settings, scoped });
+  };
+
+  const handleChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const organization = e.target.value;
+    setValue(organization);
+    setSettings({ ...settings, organization });
+  };
+
+  return (
+    <>
+      <Block title={label || 'Personal Access Token Scope'}>
+        <p>
+          If you are using an organization-scoped token, please enter the organization. Otherwise make sure to create an
+          unscoped token.{' '}
+          {DOC_URL.PLUGIN.AZUREDEVOPS.AUTH_TOKEN !== '' && (
+            <ExternalLink link={DOC_URL.PLUGIN.AZUREDEVOPS.AUTH_TOKEN}>Learn about how to create a PAT</ExternalLink>
+          )}
+        </p>
+        <Radio.Group value={settings.scoped} onChange={handleChange}>
+          <Radio value={false}>Unscoped</Radio>
+          <Radio value={true}>Scoped</Radio>
+        </Radio.Group>
+      </Block>
+      <Block>
+        <Input
+          style={{ width: 386 }}
+          placeholder="Your organization"
+          value={value}
+          onChange={handleChangeValue}
+          disabled={!settings.scoped}
+        />
+      </Block>
+    </>
+  );
+};

--- a/config-ui/src/types/connection.ts
+++ b/config-ui/src/types/connection.ts
@@ -31,6 +31,7 @@ export interface IConnectionAPI {
   companyId?: number;
   proxy: string;
   rateLimitPerHour?: number;
+  organization?: string;
 }
 
 export interface IConnectionTestResult {
@@ -85,4 +86,5 @@ export interface IConnection {
   companyId?: number;
   proxy: string;
   rateLimitPerHour?: number;
+  organization?: string;
 }


### PR DESCRIPTION
Users can now create an Azure DevOps connection using a PAT that is limited to a single organization. This means users are not required to use PATs with access to all their organizations.